### PR TITLE
fix: disable setting pressure to default value on web

### DIFF
--- a/lib/src/view/notifier/scribble_notifier.dart
+++ b/lib/src/view/notifier/scribble_notifier.dart
@@ -427,7 +427,7 @@ class ScribbleNotifier extends ScribbleNotifierBase
 
   /// Converts a pointer event to the [Point] on the canvas.
   Point _getPointFromEvent(PointerEvent event) {
-    final p = kIsWeb || event.pressureMin == event.pressureMax
+    final p = event.pressureMin == event.pressureMax
         ? 0.5
         : (event.pressure - event.pressureMin) /
             (event.pressureMax - event.pressureMin);


### PR DESCRIPTION
## Description

![image](https://github.com/user-attachments/assets/c6098beb-2d90-4142-a5bc-541c5cc8d96d)

Pressure works on web. We should remove the flag that sets the pressure value to 0.5 when on the web.

## Checklist

- [x ] My PR title is in the style of [conventional commits](https://www.conventionalcommits.org/)
- [ x] All public facing APIs are documented with [dartdoc](https://dart.dev/guides/language/effective-dart/documentation)
- [ ] I have added tests to cover my changes
