### PR TITLE
fix: guard repaint boundary keys via per-instance attach/detach

### DIFF
--- a/lib/src/view/notifier/scribble_notifier.dart
+++ b/lib/src/view/notifier/scribble_notifier.dart
@@ -26,6 +26,19 @@ abstract class ScribbleNotifierBase extends ValueNotifier<ScribbleState> {
   /// access it from the [renderImage] method.
   GlobalKey get repaintBoundaryKey;
 
+  /// Attaches a [GlobalKey] representing a [RepaintBoundary] used by a
+  /// [Scribble] widget instance.
+  ///
+  /// Default implementation is a no-op so external implementations of the
+  /// notifier don't need to override this method.
+  void attachRepaintBoundaryKey(GlobalKey key) {}
+
+  /// Detaches a previously attached [GlobalKey].
+  ///
+  /// Default implementation is a no-op so external implementations of the
+  /// notifier don't need to override this method.
+  void detachRepaintBoundaryKey(GlobalKey key) {}
+
   /// Should be called when the pointer hovers over the canvas with the
   /// corresponding [event].
   void onPointerHover(PointerHoverEvent event);
@@ -130,10 +143,32 @@ class ScribbleNotifier extends ScribbleNotifierBase
   /// receive a map.
   Sketch get currentSketch => value.sketch;
 
+  // Fallback key for backward compatibility when no widget-attached key exists.
   final GlobalKey _repaintBoundaryKey = GlobalKey();
 
+  // Tracks keys of mounted Scribble widgets using this notifier.
+  // The last attached key is preferred for image rendering to avoid collisions 
+  // when the same notifier is used by multiple widgets concurrently.
+  final List<GlobalKey> _attachedRepaintBoundaryKeys = <GlobalKey>[];
+
   @override
-  GlobalKey get repaintBoundaryKey => _repaintBoundaryKey;
+  GlobalKey get repaintBoundaryKey =>
+      _attachedRepaintBoundaryKeys.isNotEmpty
+          ? _attachedRepaintBoundaryKeys.last
+          : _repaintBoundaryKey;
+
+  @override
+  void attachRepaintBoundaryKey(GlobalKey key) {
+    // Avoid duplicates while preserving order semantics
+    if (!_attachedRepaintBoundaryKeys.contains(key)) {
+      _attachedRepaintBoundaryKeys.add(key);
+    }
+  }
+
+  @override
+  void detachRepaintBoundaryKey(GlobalKey key) {
+    _attachedRepaintBoundaryKeys.remove(key);
+  }
 
   /// The [SketchSimplifier] that is used to simplify the lines of the sketch.
   ///

--- a/lib/src/view/notifier/scribble_notifier.dart
+++ b/lib/src/view/notifier/scribble_notifier.dart
@@ -147,15 +147,14 @@ class ScribbleNotifier extends ScribbleNotifierBase
   final GlobalKey _repaintBoundaryKey = GlobalKey();
 
   // Tracks keys of mounted Scribble widgets using this notifier.
-  // The last attached key is preferred for image rendering to avoid collisions 
+  // The last attached key is preferred for image rendering to avoid collisions
   // when the same notifier is used by multiple widgets concurrently.
   final List<GlobalKey> _attachedRepaintBoundaryKeys = <GlobalKey>[];
 
   @override
-  GlobalKey get repaintBoundaryKey =>
-      _attachedRepaintBoundaryKeys.isNotEmpty
-          ? _attachedRepaintBoundaryKeys.last
-          : _repaintBoundaryKey;
+  GlobalKey get repaintBoundaryKey => _attachedRepaintBoundaryKeys.isNotEmpty
+      ? _attachedRepaintBoundaryKeys.last
+      : _repaintBoundaryKey;
 
   @override
   void attachRepaintBoundaryKey(GlobalKey key) {
@@ -168,6 +167,25 @@ class ScribbleNotifier extends ScribbleNotifierBase
   @override
   void detachRepaintBoundaryKey(GlobalKey key) {
     _attachedRepaintBoundaryKeys.remove(key);
+  }
+
+  @override
+  Future<ByteData> renderImage({
+    double pixelRatio = 1.0,
+    ui.ImageByteFormat format = ui.ImageByteFormat.png,
+  }) {
+    assert(() {
+      if (_attachedRepaintBoundaryKeys.isEmpty) {
+        debugPrint(
+          '[scribble] renderImage() is falling back to an internal GlobalKey. '
+          'If you implement ScribbleNotifierBase yourself, override '
+          'attachRepaintBoundaryKey/detachRepaintBoundaryKey so Scribble widgets '
+          'can register their RepaintBoundary. This fallback will be removed in a future release.',
+        );
+      }
+      return true;
+    }());
+    return super.renderImage(pixelRatio: pixelRatio, format: format);
   }
 
   /// The [SketchSimplifier] that is used to simplify the lines of the sketch.

--- a/lib/src/view/scribble.dart
+++ b/lib/src/view/scribble.dart
@@ -14,7 +14,7 @@ import 'package:scribble/src/view/state/scribble.state.dart';
 /// You can control its behavior from code using the [notifier] instance you
 /// pass in.
 /// {@endtemplate}
-class Scribble extends StatelessWidget {
+class Scribble extends StatefulWidget {
   /// {@macro scribble}
   const Scribble({
     /// The notifier that controls this canvas.
@@ -47,27 +47,58 @@ class Scribble extends StatelessWidget {
   final bool simulatePressure;
 
   @override
+  State<Scribble> createState() => _ScribbleState();
+}
+
+class _ScribbleState extends State<Scribble> {
+  late final GlobalKey _localRepaintBoundaryKey;
+
+  @override
+  void initState() {
+    super.initState();
+    _localRepaintBoundaryKey = GlobalKey(
+      debugLabel: 'scribble_${identityHashCode(this)}',
+    );
+    widget.notifier.attachRepaintBoundaryKey(_localRepaintBoundaryKey);
+  }
+
+  @override
+  void didUpdateWidget(covariant Scribble oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (!identical(oldWidget.notifier, widget.notifier)) {
+      oldWidget.notifier.detachRepaintBoundaryKey(_localRepaintBoundaryKey);
+      widget.notifier.attachRepaintBoundaryKey(_localRepaintBoundaryKey);
+    }
+  }
+
+  @override
+  void dispose() {
+    widget.notifier.detachRepaintBoundaryKey(_localRepaintBoundaryKey);
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return ValueListenableBuilder<ScribbleState>(
-      valueListenable: notifier,
+      valueListenable: widget.notifier,
       builder: (context, state, _) {
         final drawCurrentTool =
-            drawPen && state is Drawing || drawEraser && state is Erasing;
+            widget.drawPen && state is Drawing || widget.drawEraser && state is Erasing;
         final child = SizedBox.expand(
           child: CustomPaint(
             foregroundPainter: ScribbleEditingPainter(
               state: state,
-              drawPointer: drawPen,
-              drawEraser: drawEraser,
-              simulatePressure: simulatePressure,
+              drawPointer: widget.drawPen,
+              drawEraser: widget.drawEraser,
+              simulatePressure: widget.simulatePressure,
             ),
             child: RepaintBoundary(
-              key: notifier.repaintBoundaryKey,
+              key: _localRepaintBoundaryKey,
               child: CustomPaint(
                 painter: ScribblePainter(
                   sketch: state.sketch,
                   scaleFactor: state.scaleFactor,
-                  simulatePressure: simulatePressure,
+                  simulatePressure: widget.simulatePressure,
                 ),
               ),
             ),
@@ -83,13 +114,13 @@ class Scribble extends StatelessWidget {
                               .contains(PointerDeviceKind.mouse)
                       ? SystemMouseCursors.none
                       : MouseCursor.defer,
-                  onExit: notifier.onPointerExit,
+                  onExit: widget.notifier.onPointerExit,
                   child: Listener(
-                    onPointerDown: notifier.onPointerDown,
-                    onPointerMove: notifier.onPointerUpdate,
-                    onPointerUp: notifier.onPointerUp,
-                    onPointerHover: notifier.onPointerHover,
-                    onPointerCancel: notifier.onPointerCancel,
+                    onPointerDown: widget.notifier.onPointerDown,
+                    onPointerMove: widget.notifier.onPointerUpdate,
+                    onPointerUp: widget.notifier.onPointerUp,
+                    onPointerHover: widget.notifier.onPointerHover,
+                    onPointerCancel: widget.notifier.onPointerCancel,
                     child: child,
                   ),
                 ),

--- a/test/src/view/scribble_test.dart
+++ b/test/src/view/scribble_test.dart
@@ -44,5 +44,30 @@ void main() {
         },
       );
     });
+
+    testWidgets(
+      'does not throw when sharing a notifier across multiple instances',
+      (WidgetTester tester) async {
+        final notifier = ScribbleNotifier();
+        addTearDown(notifier.dispose);
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: Column(
+                children: [
+                  Expanded(child: Scribble(notifier: notifier)),
+                  Expanded(child: Scribble(notifier: notifier)),
+                ],
+              ),
+            ),
+          ),
+        );
+
+        await tester.pumpAndSettle();
+
+        expect(tester.takeException(), isNull);
+      },
+    );
   });
 }


### PR DESCRIPTION
<!--
Thanks for contributing!

Provide a description of your changes below and a general summary in the title

Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

### problem

- Share of a single `repaintBoundaryKey` across multiple `Scribble` widgets caused `Multiple widgets used the same GlobalKey` when go_router kept two `/notes/:noteId/edit` pages alive via `MaterialPage(maintainState: true, key: state.pageKey)` (see it-contest repo, branch design/clean-dev-xodnd @f13a67f / dev @38f056b).

```text
══╡ EXCEPTION CAUGHT BY WIDGETS LIBRARY
╞═══════════════════════════════════════════════════════════
The following assertion was thrown while finalizing the widget tree:
Multiple widgets used the same GlobalKey.
The key [GlobalKey#d6fd3] was used by multiple widgets. The parents of those widgets
were:
- CustomPaint(renderObject: RenderCustomPaint#f1798 NEEDS-PAINT)
- CustomPaint(renderObject: RenderCustomPaint#b3622)
A GlobalKey can only be specified on one widget at a time in the widget tree.

When the exception was thrown, this was the stack:
#0      BuildOwner._debugVerifyGlobalKeyReservation.<anonymous closure>.<anonymous
closure>.<anonymous closure> (package:flutter/src/widgets/framework.dart:3220:13)
#1      _LinkedHashMapMixin.forEach (dart:_compact_hash:764:13)
#2      BuildOwner._debugVerifyGlobalKeyReservation.<anonymous closure>.<anonymous
closure> (package:flutter/src/widgets/framework.dart:3164:20)
#3      _LinkedHashMapMixin.forEach (dart:_compact_hash:764:13)
#4      BuildOwner._debugVerifyGlobalKeyReservation.<anonymous closure>
(package:flutter/src/widgets/framework.dart:3158:36)
#5      BuildOwner._debugVerifyGlobalKeyReservation
(package:flutter/src/widgets/framework.dart:3228:6)
#6      BuildOwner.finalizeTree.<anonymous closure>
(package:flutter/src/widgets/framework.dart:3291:11)
#7      BuildOwner.finalizeTree (package:flutter/src/widgets/framework.dart:3378:8)
#8      WidgetsBinding.drawFrame (package:flutter/src/widgets/binding.dart:1247:19)
#9      RendererBinding._handlePersistentFrameCallback
(package:flutter/src/rendering/binding.dart:495:5)
#10     SchedulerBinding._invokeFrameCallback
(package:flutter/src/scheduler/binding.dart:1438:15)
#11     SchedulerBinding.handleDrawFrame
(package:flutter/src/scheduler/binding.dart:1351:9)
#12     SchedulerBinding._handleDrawFrame
(package:flutter/src/scheduler/binding.dart:1204:5)
#13     _invoke (dart:ui/hooks.dart:331:13)
#14     PlatformDispatcher._drawFrame (dart:ui/platform_dispatcher.dart:444:5)
#15     _drawFrame (dart:ui/hooks.dart:303:31)
═══════════════════════════════════════════════════════════════════════════════════════
═════════════

Another exception was thrown: Multiple widgets used the same GlobalKey.
Another exception was thrown: Multiple widgets used the same GlobalKey.
Another exception was thrown: Multiple widgets used the same GlobalKey.
```

### how i solved

- Converted `Scribble` to a `StatefulWidget`, giving each instance its own `_localRepaintBoundaryKey` and hooking the notifier through new `attachRepaintBoundaryKey` / `detachRepaintBoundaryKey` lifecycle methods.
- Added a debug-only warning in `ScribbleNotifier.renderImage` whenever the legacy fallback key is used so integrators are nudged to adopt the new lifecycle before the fallback disappears.

### how it works

- `ScribbleNotifier` tracks the attached keys and falls back to the legacy key so existing code keeps working; `renderImage` now resolves to the most recently attached surface, which matches the single-canvas-per-notifier contract.

### verification

- Manual verification: dependency override from `https://github.com/timcreatedit/scribble` `ref: main` to `https://github.com/ehdnd/scribble` `ref: fix/globalkey-collision` inside `https://github.com/tryCatchPing/it-contest` (branches design/clean-dev-xodnd @f13a67f / dev @38f056b). Restored `MaterialPage(maintainState: true)`—which previously forced us to fallback to `false`—and confirmed linked-note navigation (link tap, backlinks panel, note list) no longer emits the GlobalKey assertion.
- Automated verification: `flutter test` passes on Flutter 3.32.5 (FVM). The new widget test (`Scribble does not throw when sharing a notifier across multiple instances`) fails against pre-fix sources, confirming regression coverage.
- ,, Attempts to build a minimal reproduction outside of the app were unsuccessful; the failure only appeared once the go_router + Riverpod keepAlive + maintainState stack was in place. If anyone manages to isolate a smaller example, happy to add it.


### note for integrators

- Custom `ScribbleNotifierBase` implementations must override `attachRepaintBoundaryKey` / `detachRepaintBoundaryKey` to keep `renderImage` working; consider this a behavior change for external notifiers.
  - In debug builds, continuing to rely on the legacy fallback GlobalKey now prints a warning so integrators notice the upcoming change.

## Checklist

- [x] My PR title is in the style of [conventional commits](https://www.conventionalcommits.org/)
- [x] All public facing APIs are documented with [dartdoc](https://dart.dev/guides/language/effective-dart/documentation)
- [x] I have added tests to cover my changes
