### PR TITLE
chore(deps): [BREAKING] Support freezed 3

### DIFF
--- a/lib/src/domain/model/point/point.dart
+++ b/lib/src/domain/model/point/point.dart
@@ -8,7 +8,7 @@ part 'point.g.dart';
 /// pressure value.
 /// {@endtemplate}
 @Freezed()
-class Point with _$Point {
+abstract class Point with _$Point {
   /// {@macro point}
   const factory Point(
     double x,

--- a/lib/src/domain/model/point/point.freezed.dart
+++ b/lib/src/domain/model/point/point.freezed.dart
@@ -1,5 +1,5 @@
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -9,144 +9,30 @@ part of 'point.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
-
-Point _$PointFromJson(Map<String, dynamic> json) {
-  return _Point.fromJson(json);
-}
 
 /// @nodoc
 mixin _$Point {
-  double get x => throw _privateConstructorUsedError;
-  double get y => throw _privateConstructorUsedError;
-  double get pressure => throw _privateConstructorUsedError;
-
-  /// Serializes this Point to a JSON map.
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  double get x;
+  double get y;
+  double get pressure;
 
   /// Create a copy of Point
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
-  $PointCopyWith<Point> get copyWith => throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class $PointCopyWith<$Res> {
-  factory $PointCopyWith(Point value, $Res Function(Point) then) =
-      _$PointCopyWithImpl<$Res, Point>;
-  @useResult
-  $Res call({double x, double y, double pressure});
-}
-
-/// @nodoc
-class _$PointCopyWithImpl<$Res, $Val extends Point>
-    implements $PointCopyWith<$Res> {
-  _$PointCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  /// Create a copy of Point
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? x = null,
-    Object? y = null,
-    Object? pressure = null,
-  }) {
-    return _then(_value.copyWith(
-      x: null == x
-          ? _value.x
-          : x // ignore: cast_nullable_to_non_nullable
-              as double,
-      y: null == y
-          ? _value.y
-          : y // ignore: cast_nullable_to_non_nullable
-              as double,
-      pressure: null == pressure
-          ? _value.pressure
-          : pressure // ignore: cast_nullable_to_non_nullable
-              as double,
-    ) as $Val);
-  }
-}
+  $PointCopyWith<Point> get copyWith =>
+      _$PointCopyWithImpl<Point>(this as Point, _$identity);
 
-/// @nodoc
-abstract class _$$PointImplCopyWith<$Res> implements $PointCopyWith<$Res> {
-  factory _$$PointImplCopyWith(
-          _$PointImpl value, $Res Function(_$PointImpl) then) =
-      __$$PointImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call({double x, double y, double pressure});
-}
-
-/// @nodoc
-class __$$PointImplCopyWithImpl<$Res>
-    extends _$PointCopyWithImpl<$Res, _$PointImpl>
-    implements _$$PointImplCopyWith<$Res> {
-  __$$PointImplCopyWithImpl(
-      _$PointImpl _value, $Res Function(_$PointImpl) _then)
-      : super(_value, _then);
-
-  /// Create a copy of Point
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? x = null,
-    Object? y = null,
-    Object? pressure = null,
-  }) {
-    return _then(_$PointImpl(
-      null == x
-          ? _value.x
-          : x // ignore: cast_nullable_to_non_nullable
-              as double,
-      null == y
-          ? _value.y
-          : y // ignore: cast_nullable_to_non_nullable
-              as double,
-      pressure: null == pressure
-          ? _value.pressure
-          : pressure // ignore: cast_nullable_to_non_nullable
-              as double,
-    ));
-  }
-}
-
-/// @nodoc
-@JsonSerializable()
-class _$PointImpl extends _Point {
-  const _$PointImpl(this.x, this.y, {this.pressure = 0.5}) : super._();
-
-  factory _$PointImpl.fromJson(Map<String, dynamic> json) =>
-      _$$PointImplFromJson(json);
-
-  @override
-  final double x;
-  @override
-  final double y;
-  @override
-  @JsonKey()
-  final double pressure;
-
-  @override
-  String toString() {
-    return 'Point(x: $x, y: $y, pressure: $pressure)';
-  }
+  /// Serializes this Point to a JSON map.
+  Map<String, dynamic> toJson();
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$PointImpl &&
+            other is Point &&
             (identical(other.x, x) || other.x == x) &&
             (identical(other.y, y) || other.y == y) &&
             (identical(other.pressure, pressure) ||
@@ -157,40 +43,300 @@ class _$PointImpl extends _Point {
   @override
   int get hashCode => Object.hash(runtimeType, x, y, pressure);
 
-  /// Create a copy of Point
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  @pragma('vm:prefer-inline')
-  _$$PointImplCopyWith<_$PointImpl> get copyWith =>
-      __$$PointImplCopyWithImpl<_$PointImpl>(this, _$identity);
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$PointImplToJson(
-      this,
-    );
+  String toString() {
+    return 'Point(x: $x, y: $y, pressure: $pressure)';
   }
 }
 
-abstract class _Point extends Point {
-  const factory _Point(final double x, final double y,
-      {final double pressure}) = _$PointImpl;
-  const _Point._() : super._();
+/// @nodoc
+abstract mixin class $PointCopyWith<$Res> {
+  factory $PointCopyWith(Point value, $Res Function(Point) _then) =
+      _$PointCopyWithImpl;
+  @useResult
+  $Res call({double x, double y, double pressure});
+}
 
-  factory _Point.fromJson(Map<String, dynamic> json) = _$PointImpl.fromJson;
+/// @nodoc
+class _$PointCopyWithImpl<$Res> implements $PointCopyWith<$Res> {
+  _$PointCopyWithImpl(this._self, this._then);
+
+  final Point _self;
+  final $Res Function(Point) _then;
+
+  /// Create a copy of Point
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? x = null,
+    Object? y = null,
+    Object? pressure = null,
+  }) {
+    return _then(_self.copyWith(
+      x: null == x
+          ? _self.x
+          : x // ignore: cast_nullable_to_non_nullable
+              as double,
+      y: null == y
+          ? _self.y
+          : y // ignore: cast_nullable_to_non_nullable
+              as double,
+      pressure: null == pressure
+          ? _self.pressure
+          : pressure // ignore: cast_nullable_to_non_nullable
+              as double,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [Point].
+extension PointPatterns on Point {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_Point value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Point() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_Point value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Point():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_Point value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Point() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(double x, double y, double pressure)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Point() when $default != null:
+        return $default(_that.x, _that.y, _that.pressure);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(double x, double y, double pressure) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Point():
+        return $default(_that.x, _that.y, _that.pressure);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(double x, double y, double pressure)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Point() when $default != null:
+        return $default(_that.x, _that.y, _that.pressure);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _Point extends Point {
+  const _Point(this.x, this.y, {this.pressure = 0.5}) : super._();
+  factory _Point.fromJson(Map<String, dynamic> json) => _$PointFromJson(json);
 
   @override
-  double get x;
+  final double x;
   @override
-  double get y;
+  final double y;
   @override
-  double get pressure;
+  @JsonKey()
+  final double pressure;
 
   /// Create a copy of Point
   /// with the given fields replaced by the non-null parameter values.
   @override
   @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$PointImplCopyWith<_$PointImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+  @pragma('vm:prefer-inline')
+  _$PointCopyWith<_Point> get copyWith =>
+      __$PointCopyWithImpl<_Point>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$PointToJson(
+      this,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _Point &&
+            (identical(other.x, x) || other.x == x) &&
+            (identical(other.y, y) || other.y == y) &&
+            (identical(other.pressure, pressure) ||
+                other.pressure == pressure));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, x, y, pressure);
+
+  @override
+  String toString() {
+    return 'Point(x: $x, y: $y, pressure: $pressure)';
+  }
 }
+
+/// @nodoc
+abstract mixin class _$PointCopyWith<$Res> implements $PointCopyWith<$Res> {
+  factory _$PointCopyWith(_Point value, $Res Function(_Point) _then) =
+      __$PointCopyWithImpl;
+  @override
+  @useResult
+  $Res call({double x, double y, double pressure});
+}
+
+/// @nodoc
+class __$PointCopyWithImpl<$Res> implements _$PointCopyWith<$Res> {
+  __$PointCopyWithImpl(this._self, this._then);
+
+  final _Point _self;
+  final $Res Function(_Point) _then;
+
+  /// Create a copy of Point
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? x = null,
+    Object? y = null,
+    Object? pressure = null,
+  }) {
+    return _then(_Point(
+      null == x
+          ? _self.x
+          : x // ignore: cast_nullable_to_non_nullable
+              as double,
+      null == y
+          ? _self.y
+          : y // ignore: cast_nullable_to_non_nullable
+              as double,
+      pressure: null == pressure
+          ? _self.pressure
+          : pressure // ignore: cast_nullable_to_non_nullable
+              as double,
+    ));
+  }
+}
+
+// dart format on

--- a/lib/src/domain/model/point/point.g.dart
+++ b/lib/src/domain/model/point/point.g.dart
@@ -6,14 +6,13 @@ part of 'point.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$PointImpl _$$PointImplFromJson(Map<String, dynamic> json) => _$PointImpl(
+_Point _$PointFromJson(Map<String, dynamic> json) => _Point(
       (json['x'] as num).toDouble(),
       (json['y'] as num).toDouble(),
       pressure: (json['pressure'] as num?)?.toDouble() ?? 0.5,
     );
 
-Map<String, dynamic> _$$PointImplToJson(_$PointImpl instance) =>
-    <String, dynamic>{
+Map<String, dynamic> _$PointToJson(_Point instance) => <String, dynamic>{
       'x': instance.x,
       'y': instance.y,
       'pressure': instance.pressure,

--- a/lib/src/domain/model/sketch/sketch.dart
+++ b/lib/src/domain/model/sketch/sketch.dart
@@ -9,7 +9,7 @@ part 'sketch.g.dart';
 
 /// Represents a sketch with a list of [SketchLine]s.
 @freezed
-class Sketch with _$Sketch {
+abstract class Sketch with _$Sketch {
   /// Represents a sketch with a list of [SketchLine]s.
   const factory Sketch({
     required List<SketchLine> lines,

--- a/lib/src/domain/model/sketch/sketch.freezed.dart
+++ b/lib/src/domain/model/sketch/sketch.freezed.dart
@@ -1,5 +1,5 @@
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -9,79 +9,56 @@ part of 'sketch.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
-
-Sketch _$SketchFromJson(Map<String, dynamic> json) {
-  return _Sketch.fromJson(json);
-}
 
 /// @nodoc
 mixin _$Sketch {
-  List<SketchLine> get lines => throw _privateConstructorUsedError;
-
-  /// Serializes this Sketch to a JSON map.
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  List<SketchLine> get lines;
 
   /// Create a copy of Sketch
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
-  $SketchCopyWith<Sketch> get copyWith => throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class $SketchCopyWith<$Res> {
-  factory $SketchCopyWith(Sketch value, $Res Function(Sketch) then) =
-      _$SketchCopyWithImpl<$Res, Sketch>;
-  @useResult
-  $Res call({List<SketchLine> lines});
-}
-
-/// @nodoc
-class _$SketchCopyWithImpl<$Res, $Val extends Sketch>
-    implements $SketchCopyWith<$Res> {
-  _$SketchCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  /// Create a copy of Sketch
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
+  $SketchCopyWith<Sketch> get copyWith =>
+      _$SketchCopyWithImpl<Sketch>(this as Sketch, _$identity);
+
+  /// Serializes this Sketch to a JSON map.
+  Map<String, dynamic> toJson();
+
   @override
-  $Res call({
-    Object? lines = null,
-  }) {
-    return _then(_value.copyWith(
-      lines: null == lines
-          ? _value.lines
-          : lines // ignore: cast_nullable_to_non_nullable
-              as List<SketchLine>,
-    ) as $Val);
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is Sketch &&
+            const DeepCollectionEquality().equals(other.lines, lines));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, const DeepCollectionEquality().hash(lines));
+
+  @override
+  String toString() {
+    return 'Sketch(lines: $lines)';
   }
 }
 
 /// @nodoc
-abstract class _$$SketchImplCopyWith<$Res> implements $SketchCopyWith<$Res> {
-  factory _$$SketchImplCopyWith(
-          _$SketchImpl value, $Res Function(_$SketchImpl) then) =
-      __$$SketchImplCopyWithImpl<$Res>;
-  @override
+abstract mixin class $SketchCopyWith<$Res> {
+  factory $SketchCopyWith(Sketch value, $Res Function(Sketch) _then) =
+      _$SketchCopyWithImpl;
   @useResult
   $Res call({List<SketchLine> lines});
 }
 
 /// @nodoc
-class __$$SketchImplCopyWithImpl<$Res>
-    extends _$SketchCopyWithImpl<$Res, _$SketchImpl>
-    implements _$$SketchImplCopyWith<$Res> {
-  __$$SketchImplCopyWithImpl(
-      _$SketchImpl _value, $Res Function(_$SketchImpl) _then)
-      : super(_value, _then);
+class _$SketchCopyWithImpl<$Res> implements $SketchCopyWith<$Res> {
+  _$SketchCopyWithImpl(this._self, this._then);
+
+  final Sketch _self;
+  final $Res Function(Sketch) _then;
 
   /// Create a copy of Sketch
   /// with the given fields replaced by the non-null parameter values.
@@ -90,22 +67,177 @@ class __$$SketchImplCopyWithImpl<$Res>
   $Res call({
     Object? lines = null,
   }) {
-    return _then(_$SketchImpl(
+    return _then(_self.copyWith(
       lines: null == lines
-          ? _value._lines
+          ? _self.lines
           : lines // ignore: cast_nullable_to_non_nullable
               as List<SketchLine>,
     ));
   }
 }
 
+/// Adds pattern-matching-related methods to [Sketch].
+extension SketchPatterns on Sketch {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_Sketch value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Sketch() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_Sketch value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Sketch():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_Sketch value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Sketch() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(List<SketchLine> lines)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Sketch() when $default != null:
+        return $default(_that.lines);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(List<SketchLine> lines) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Sketch():
+        return $default(_that.lines);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(List<SketchLine> lines)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Sketch() when $default != null:
+        return $default(_that.lines);
+      case _:
+        return null;
+    }
+  }
+}
+
 /// @nodoc
 @JsonSerializable()
-class _$SketchImpl implements _Sketch {
-  const _$SketchImpl({required final List<SketchLine> lines}) : _lines = lines;
-
-  factory _$SketchImpl.fromJson(Map<String, dynamic> json) =>
-      _$$SketchImplFromJson(json);
+class _Sketch implements Sketch {
+  const _Sketch({required final List<SketchLine> lines}) : _lines = lines;
+  factory _Sketch.fromJson(Map<String, dynamic> json) => _$SketchFromJson(json);
 
   final List<SketchLine> _lines;
   @override
@@ -115,16 +247,26 @@ class _$SketchImpl implements _Sketch {
     return EqualUnmodifiableListView(_lines);
   }
 
+  /// Create a copy of Sketch
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  String toString() {
-    return 'Sketch(lines: $lines)';
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$SketchCopyWith<_Sketch> get copyWith =>
+      __$SketchCopyWithImpl<_Sketch>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$SketchToJson(
+      this,
+    );
   }
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$SketchImpl &&
+            other is _Sketch &&
             const DeepCollectionEquality().equals(other._lines, _lines));
   }
 
@@ -133,34 +275,42 @@ class _$SketchImpl implements _Sketch {
   int get hashCode =>
       Object.hash(runtimeType, const DeepCollectionEquality().hash(_lines));
 
-  /// Create a copy of Sketch
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  @pragma('vm:prefer-inline')
-  _$$SketchImplCopyWith<_$SketchImpl> get copyWith =>
-      __$$SketchImplCopyWithImpl<_$SketchImpl>(this, _$identity);
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$SketchImplToJson(
-      this,
-    );
+  String toString() {
+    return 'Sketch(lines: $lines)';
   }
 }
 
-abstract class _Sketch implements Sketch {
-  const factory _Sketch({required final List<SketchLine> lines}) = _$SketchImpl;
-
-  factory _Sketch.fromJson(Map<String, dynamic> json) = _$SketchImpl.fromJson;
-
+/// @nodoc
+abstract mixin class _$SketchCopyWith<$Res> implements $SketchCopyWith<$Res> {
+  factory _$SketchCopyWith(_Sketch value, $Res Function(_Sketch) _then) =
+      __$SketchCopyWithImpl;
   @override
-  List<SketchLine> get lines;
+  @useResult
+  $Res call({List<SketchLine> lines});
+}
+
+/// @nodoc
+class __$SketchCopyWithImpl<$Res> implements _$SketchCopyWith<$Res> {
+  __$SketchCopyWithImpl(this._self, this._then);
+
+  final _Sketch _self;
+  final $Res Function(_Sketch) _then;
 
   /// Create a copy of Sketch
   /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$SketchImplCopyWith<_$SketchImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? lines = null,
+  }) {
+    return _then(_Sketch(
+      lines: null == lines
+          ? _self._lines
+          : lines // ignore: cast_nullable_to_non_nullable
+              as List<SketchLine>,
+    ));
+  }
 }
+
+// dart format on

--- a/lib/src/domain/model/sketch/sketch.g.dart
+++ b/lib/src/domain/model/sketch/sketch.g.dart
@@ -6,13 +6,12 @@ part of 'sketch.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$SketchImpl _$$SketchImplFromJson(Map<String, dynamic> json) => _$SketchImpl(
+_Sketch _$SketchFromJson(Map<String, dynamic> json) => _Sketch(
       lines: (json['lines'] as List<dynamic>)
           .map((e) => SketchLine.fromJson(e as Map<String, dynamic>))
           .toList(),
     );
 
-Map<String, dynamic> _$$SketchImplToJson(_$SketchImpl instance) =>
-    <String, dynamic>{
+Map<String, dynamic> _$SketchToJson(_Sketch instance) => <String, dynamic>{
       'lines': instance.lines.map((e) => e.toJson()).toList(),
     };

--- a/lib/src/domain/model/sketch_line/sketch_line.dart
+++ b/lib/src/domain/model/sketch_line/sketch_line.dart
@@ -8,7 +8,7 @@ part 'sketch_line.g.dart';
 /// Represents a line in a sketch.
 /// {@endtemplate}
 @freezed
-class SketchLine with _$SketchLine {
+abstract class SketchLine with _$SketchLine {
   /// {@macro sketch_line}
   const factory SketchLine({
     /// The points that make up the line

--- a/lib/src/domain/model/sketch_line/sketch_line.freezed.dart
+++ b/lib/src/domain/model/sketch_line/sketch_line.freezed.dart
@@ -1,5 +1,5 @@
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -9,99 +9,66 @@ part of 'sketch_line.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
-
-SketchLine _$SketchLineFromJson(Map<String, dynamic> json) {
-  return _SketchLine.fromJson(json);
-}
 
 /// @nodoc
 mixin _$SketchLine {
   /// The points that make up the line
-  List<Point> get points => throw _privateConstructorUsedError;
+  List<Point> get points;
 
   /// The color of the line in hexadecimal format (ARGB)
-  int get color => throw _privateConstructorUsedError;
+  int get color;
 
   /// The width of the line
-  double get width => throw _privateConstructorUsedError;
-
-  /// Serializes this SketchLine to a JSON map.
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  double get width;
 
   /// Create a copy of SketchLine
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
-  $SketchLineCopyWith<SketchLine> get copyWith =>
-      throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class $SketchLineCopyWith<$Res> {
-  factory $SketchLineCopyWith(
-          SketchLine value, $Res Function(SketchLine) then) =
-      _$SketchLineCopyWithImpl<$Res, SketchLine>;
-  @useResult
-  $Res call({List<Point> points, int color, double width});
-}
-
-/// @nodoc
-class _$SketchLineCopyWithImpl<$Res, $Val extends SketchLine>
-    implements $SketchLineCopyWith<$Res> {
-  _$SketchLineCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  /// Create a copy of SketchLine
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
+  $SketchLineCopyWith<SketchLine> get copyWith =>
+      _$SketchLineCopyWithImpl<SketchLine>(this as SketchLine, _$identity);
+
+  /// Serializes this SketchLine to a JSON map.
+  Map<String, dynamic> toJson();
+
   @override
-  $Res call({
-    Object? points = null,
-    Object? color = null,
-    Object? width = null,
-  }) {
-    return _then(_value.copyWith(
-      points: null == points
-          ? _value.points
-          : points // ignore: cast_nullable_to_non_nullable
-              as List<Point>,
-      color: null == color
-          ? _value.color
-          : color // ignore: cast_nullable_to_non_nullable
-              as int,
-      width: null == width
-          ? _value.width
-          : width // ignore: cast_nullable_to_non_nullable
-              as double,
-    ) as $Val);
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is SketchLine &&
+            const DeepCollectionEquality().equals(other.points, points) &&
+            (identical(other.color, color) || other.color == color) &&
+            (identical(other.width, width) || other.width == width));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType, const DeepCollectionEquality().hash(points), color, width);
+
+  @override
+  String toString() {
+    return 'SketchLine(points: $points, color: $color, width: $width)';
   }
 }
 
 /// @nodoc
-abstract class _$$SketchLineImplCopyWith<$Res>
-    implements $SketchLineCopyWith<$Res> {
-  factory _$$SketchLineImplCopyWith(
-          _$SketchLineImpl value, $Res Function(_$SketchLineImpl) then) =
-      __$$SketchLineImplCopyWithImpl<$Res>;
-  @override
+abstract mixin class $SketchLineCopyWith<$Res> {
+  factory $SketchLineCopyWith(
+          SketchLine value, $Res Function(SketchLine) _then) =
+      _$SketchLineCopyWithImpl;
   @useResult
   $Res call({List<Point> points, int color, double width});
 }
 
 /// @nodoc
-class __$$SketchLineImplCopyWithImpl<$Res>
-    extends _$SketchLineCopyWithImpl<$Res, _$SketchLineImpl>
-    implements _$$SketchLineImplCopyWith<$Res> {
-  __$$SketchLineImplCopyWithImpl(
-      _$SketchLineImpl _value, $Res Function(_$SketchLineImpl) _then)
-      : super(_value, _then);
+class _$SketchLineCopyWithImpl<$Res> implements $SketchLineCopyWith<$Res> {
+  _$SketchLineCopyWithImpl(this._self, this._then);
+
+  final SketchLine _self;
+  final $Res Function(SketchLine) _then;
 
   /// Create a copy of SketchLine
   /// with the given fields replaced by the non-null parameter values.
@@ -112,34 +79,190 @@ class __$$SketchLineImplCopyWithImpl<$Res>
     Object? color = null,
     Object? width = null,
   }) {
-    return _then(_$SketchLineImpl(
+    return _then(_self.copyWith(
       points: null == points
-          ? _value._points
+          ? _self.points
           : points // ignore: cast_nullable_to_non_nullable
               as List<Point>,
       color: null == color
-          ? _value.color
+          ? _self.color
           : color // ignore: cast_nullable_to_non_nullable
               as int,
       width: null == width
-          ? _value.width
+          ? _self.width
           : width // ignore: cast_nullable_to_non_nullable
               as double,
     ));
   }
 }
 
+/// Adds pattern-matching-related methods to [SketchLine].
+extension SketchLinePatterns on SketchLine {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_SketchLine value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _SketchLine() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_SketchLine value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _SketchLine():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_SketchLine value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _SketchLine() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(List<Point> points, int color, double width)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _SketchLine() when $default != null:
+        return $default(_that.points, _that.color, _that.width);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(List<Point> points, int color, double width) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _SketchLine():
+        return $default(_that.points, _that.color, _that.width);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(List<Point> points, int color, double width)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _SketchLine() when $default != null:
+        return $default(_that.points, _that.color, _that.width);
+      case _:
+        return null;
+    }
+  }
+}
+
 /// @nodoc
 @JsonSerializable()
-class _$SketchLineImpl implements _SketchLine {
-  const _$SketchLineImpl(
+class _SketchLine implements SketchLine {
+  const _SketchLine(
       {required final List<Point> points,
       required this.color,
       required this.width})
       : _points = points;
-
-  factory _$SketchLineImpl.fromJson(Map<String, dynamic> json) =>
-      _$$SketchLineImplFromJson(json);
+  factory _SketchLine.fromJson(Map<String, dynamic> json) =>
+      _$SketchLineFromJson(json);
 
   /// The points that make up the line
   final List<Point> _points;
@@ -160,16 +283,26 @@ class _$SketchLineImpl implements _SketchLine {
   @override
   final double width;
 
+  /// Create a copy of SketchLine
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  String toString() {
-    return 'SketchLine(points: $points, color: $color, width: $width)';
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$SketchLineCopyWith<_SketchLine> get copyWith =>
+      __$SketchLineCopyWithImpl<_SketchLine>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$SketchLineToJson(
+      this,
+    );
   }
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$SketchLineImpl &&
+            other is _SketchLine &&
             const DeepCollectionEquality().equals(other._points, _points) &&
             (identical(other.color, color) || other.color == color) &&
             (identical(other.width, width) || other.width == width));
@@ -180,47 +313,54 @@ class _$SketchLineImpl implements _SketchLine {
   int get hashCode => Object.hash(
       runtimeType, const DeepCollectionEquality().hash(_points), color, width);
 
-  /// Create a copy of SketchLine
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  @pragma('vm:prefer-inline')
-  _$$SketchLineImplCopyWith<_$SketchLineImpl> get copyWith =>
-      __$$SketchLineImplCopyWithImpl<_$SketchLineImpl>(this, _$identity);
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$SketchLineImplToJson(
-      this,
-    );
+  String toString() {
+    return 'SketchLine(points: $points, color: $color, width: $width)';
   }
 }
 
-abstract class _SketchLine implements SketchLine {
-  const factory _SketchLine(
-      {required final List<Point> points,
-      required final int color,
-      required final double width}) = _$SketchLineImpl;
-
-  factory _SketchLine.fromJson(Map<String, dynamic> json) =
-      _$SketchLineImpl.fromJson;
-
-  /// The points that make up the line
+/// @nodoc
+abstract mixin class _$SketchLineCopyWith<$Res>
+    implements $SketchLineCopyWith<$Res> {
+  factory _$SketchLineCopyWith(
+          _SketchLine value, $Res Function(_SketchLine) _then) =
+      __$SketchLineCopyWithImpl;
   @override
-  List<Point> get points;
+  @useResult
+  $Res call({List<Point> points, int color, double width});
+}
 
-  /// The color of the line in hexadecimal format (ARGB)
-  @override
-  int get color;
+/// @nodoc
+class __$SketchLineCopyWithImpl<$Res> implements _$SketchLineCopyWith<$Res> {
+  __$SketchLineCopyWithImpl(this._self, this._then);
 
-  /// The width of the line
-  @override
-  double get width;
+  final _SketchLine _self;
+  final $Res Function(_SketchLine) _then;
 
   /// Create a copy of SketchLine
   /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$SketchLineImplCopyWith<_$SketchLineImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? points = null,
+    Object? color = null,
+    Object? width = null,
+  }) {
+    return _then(_SketchLine(
+      points: null == points
+          ? _self._points
+          : points // ignore: cast_nullable_to_non_nullable
+              as List<Point>,
+      color: null == color
+          ? _self.color
+          : color // ignore: cast_nullable_to_non_nullable
+              as int,
+      width: null == width
+          ? _self.width
+          : width // ignore: cast_nullable_to_non_nullable
+              as double,
+    ));
+  }
 }
+
+// dart format on

--- a/lib/src/domain/model/sketch_line/sketch_line.g.dart
+++ b/lib/src/domain/model/sketch_line/sketch_line.g.dart
@@ -6,8 +6,7 @@ part of 'sketch_line.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$SketchLineImpl _$$SketchLineImplFromJson(Map<String, dynamic> json) =>
-    _$SketchLineImpl(
+_SketchLine _$SketchLineFromJson(Map<String, dynamic> json) => _SketchLine(
       points: (json['points'] as List<dynamic>)
           .map((e) => Point.fromJson(e as Map<String, dynamic>))
           .toList(),
@@ -15,7 +14,7 @@ _$SketchLineImpl _$$SketchLineImplFromJson(Map<String, dynamic> json) =>
       width: (json['width'] as num).toDouble(),
     );
 
-Map<String, dynamic> _$$SketchLineImplToJson(_$SketchLineImpl instance) =>
+Map<String, dynamic> _$SketchLineToJson(_SketchLine instance) =>
     <String, dynamic>{
       'points': instance.points.map((e) => e.toJson()).toList(),
       'color': instance.color,

--- a/lib/src/view/state/scribble.state.freezed.dart
+++ b/lib/src/view/state/scribble.state.freezed.dart
@@ -1,5 +1,5 @@
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -9,11 +9,8 @@ part of 'scribble.state.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
-
 ScribbleState _$ScribbleStateFromJson(Map<String, dynamic> json) {
   switch (json['runtimeType']) {
     case 'drawing':
@@ -30,22 +27,21 @@ ScribbleState _$ScribbleStateFromJson(Map<String, dynamic> json) {
 /// @nodoc
 mixin _$ScribbleState {
   /// The current state of the sketch
-  Sketch get sketch => throw _privateConstructorUsedError;
+  Sketch get sketch;
 
   /// Which pointers are allowed for drawing and will be captured by the
   /// scribble widget.
-  ScribblePointerMode get allowedPointersMode =>
-      throw _privateConstructorUsedError;
+  ScribblePointerMode get allowedPointersMode;
 
   /// The ids of all supported pointers that are currently interacting with
   /// the widget.
-  List<int> get activePointerIds => throw _privateConstructorUsedError;
+  List<int> get activePointerIds;
 
   /// The current position of the pointer
-  Point? get pointerPosition => throw _privateConstructorUsedError;
+  Point? get pointerPosition;
 
   /// The current width of the pen
-  double get selectedWidth => throw _privateConstructorUsedError;
+  double get selectedWidth;
 
   /// {@template view.state.scribble_state.scale_factor}
   /// How much the widget is scaled at the moment.
@@ -53,7 +49,7 @@ mixin _$ScribbleState {
   /// Can be used if zoom functionality is needed
   /// (e.g. through InteractiveViewer) so that the pen width remains the same.
   /// {@endtemplate}
-  double get scaleFactor => throw _privateConstructorUsedError;
+  double get scaleFactor;
 
   /// {@template view.state.scribble_state.simplification_tolerance}
   /// The current tolerance of simplification, in pixels.
@@ -61,55 +57,253 @@ mixin _$ScribbleState {
   /// Lines will be simplified when they are finished. A value of 0 (default)
   /// will mean no simplification.
   /// {@endtemplate}
-  double get simplificationTolerance => throw _privateConstructorUsedError;
+  double get simplificationTolerance;
+
+  /// Create a copy of ScribbleState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $ScribbleStateCopyWith<ScribbleState> get copyWith =>
+      _$ScribbleStateCopyWithImpl<ScribbleState>(
+          this as ScribbleState, _$identity);
+
+  /// Serializes this ScribbleState to a JSON map.
+  Map<String, dynamic> toJson();
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is ScribbleState &&
+            (identical(other.sketch, sketch) || other.sketch == sketch) &&
+            (identical(other.allowedPointersMode, allowedPointersMode) ||
+                other.allowedPointersMode == allowedPointersMode) &&
+            const DeepCollectionEquality()
+                .equals(other.activePointerIds, activePointerIds) &&
+            (identical(other.pointerPosition, pointerPosition) ||
+                other.pointerPosition == pointerPosition) &&
+            (identical(other.selectedWidth, selectedWidth) ||
+                other.selectedWidth == selectedWidth) &&
+            (identical(other.scaleFactor, scaleFactor) ||
+                other.scaleFactor == scaleFactor) &&
+            (identical(
+                    other.simplificationTolerance, simplificationTolerance) ||
+                other.simplificationTolerance == simplificationTolerance));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      sketch,
+      allowedPointersMode,
+      const DeepCollectionEquality().hash(activePointerIds),
+      pointerPosition,
+      selectedWidth,
+      scaleFactor,
+      simplificationTolerance);
+
+  @override
+  String toString() {
+    return 'ScribbleState(sketch: $sketch, allowedPointersMode: $allowedPointersMode, activePointerIds: $activePointerIds, pointerPosition: $pointerPosition, selectedWidth: $selectedWidth, scaleFactor: $scaleFactor, simplificationTolerance: $simplificationTolerance)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $ScribbleStateCopyWith<$Res> {
+  factory $ScribbleStateCopyWith(
+          ScribbleState value, $Res Function(ScribbleState) _then) =
+      _$ScribbleStateCopyWithImpl;
+  @useResult
+  $Res call(
+      {Sketch sketch,
+      ScribblePointerMode allowedPointersMode,
+      List<int> activePointerIds,
+      Point? pointerPosition,
+      double selectedWidth,
+      double scaleFactor,
+      double simplificationTolerance});
+
+  $SketchCopyWith<$Res> get sketch;
+  $PointCopyWith<$Res>? get pointerPosition;
+}
+
+/// @nodoc
+class _$ScribbleStateCopyWithImpl<$Res>
+    implements $ScribbleStateCopyWith<$Res> {
+  _$ScribbleStateCopyWithImpl(this._self, this._then);
+
+  final ScribbleState _self;
+  final $Res Function(ScribbleState) _then;
+
+  /// Create a copy of ScribbleState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? sketch = null,
+    Object? allowedPointersMode = null,
+    Object? activePointerIds = null,
+    Object? pointerPosition = freezed,
+    Object? selectedWidth = null,
+    Object? scaleFactor = null,
+    Object? simplificationTolerance = null,
+  }) {
+    return _then(_self.copyWith(
+      sketch: null == sketch
+          ? _self.sketch
+          : sketch // ignore: cast_nullable_to_non_nullable
+              as Sketch,
+      allowedPointersMode: null == allowedPointersMode
+          ? _self.allowedPointersMode
+          : allowedPointersMode // ignore: cast_nullable_to_non_nullable
+              as ScribblePointerMode,
+      activePointerIds: null == activePointerIds
+          ? _self.activePointerIds
+          : activePointerIds // ignore: cast_nullable_to_non_nullable
+              as List<int>,
+      pointerPosition: freezed == pointerPosition
+          ? _self.pointerPosition
+          : pointerPosition // ignore: cast_nullable_to_non_nullable
+              as Point?,
+      selectedWidth: null == selectedWidth
+          ? _self.selectedWidth
+          : selectedWidth // ignore: cast_nullable_to_non_nullable
+              as double,
+      scaleFactor: null == scaleFactor
+          ? _self.scaleFactor
+          : scaleFactor // ignore: cast_nullable_to_non_nullable
+              as double,
+      simplificationTolerance: null == simplificationTolerance
+          ? _self.simplificationTolerance
+          : simplificationTolerance // ignore: cast_nullable_to_non_nullable
+              as double,
+    ));
+  }
+
+  /// Create a copy of ScribbleState
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $SketchCopyWith<$Res> get sketch {
+    return $SketchCopyWith<$Res>(_self.sketch, (value) {
+      return _then(_self.copyWith(sketch: value));
+    });
+  }
+
+  /// Create a copy of ScribbleState
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $PointCopyWith<$Res>? get pointerPosition {
+    if (_self.pointerPosition == null) {
+      return null;
+    }
+
+    return $PointCopyWith<$Res>(_self.pointerPosition!, (value) {
+      return _then(_self.copyWith(pointerPosition: value));
+    });
+  }
+}
+
+/// Adds pattern-matching-related methods to [ScribbleState].
+extension ScribbleStatePatterns on ScribbleState {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
   @optionalTypeArgs
-  TResult when<TResult extends Object?>({
-    required TResult Function(
-            Sketch sketch,
-            SketchLine? activeLine,
-            ScribblePointerMode allowedPointersMode,
-            List<int> activePointerIds,
-            Point? pointerPosition,
-            int selectedColor,
-            double selectedWidth,
-            double scaleFactor,
-            double simplificationTolerance)
-        drawing,
-    required TResult Function(
-            Sketch sketch,
-            ScribblePointerMode allowedPointersMode,
-            List<int> activePointerIds,
-            Point? pointerPosition,
-            double selectedWidth,
-            double scaleFactor,
-            double simplificationTolerance)
-        erasing,
-  }) =>
-      throw _privateConstructorUsedError;
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(Drawing value)? drawing,
+    TResult Function(Erasing value)? erasing,
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case Drawing() when drawing != null:
+        return drawing(_that);
+      case Erasing() when erasing != null:
+        return erasing(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
   @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function(
-            Sketch sketch,
-            SketchLine? activeLine,
-            ScribblePointerMode allowedPointersMode,
-            List<int> activePointerIds,
-            Point? pointerPosition,
-            int selectedColor,
-            double selectedWidth,
-            double scaleFactor,
-            double simplificationTolerance)?
-        drawing,
-    TResult? Function(
-            Sketch sketch,
-            ScribblePointerMode allowedPointersMode,
-            List<int> activePointerIds,
-            Point? pointerPosition,
-            double selectedWidth,
-            double scaleFactor,
-            double simplificationTolerance)?
-        erasing,
-  }) =>
-      throw _privateConstructorUsedError;
+  TResult map<TResult extends Object?>({
+    required TResult Function(Drawing value) drawing,
+    required TResult Function(Erasing value) erasing,
+  }) {
+    final _that = this;
+    switch (_that) {
+      case Drawing():
+        return drawing(_that);
+      case Erasing():
+        return erasing(_that);
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(Drawing value)? drawing,
+    TResult? Function(Erasing value)? erasing,
+  }) {
+    final _that = this;
+    switch (_that) {
+      case Drawing() when drawing != null:
+        return drawing(_that);
+      case Erasing() when erasing != null:
+        return erasing(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
     TResult Function(
@@ -133,245 +327,162 @@ mixin _$ScribbleState {
             double simplificationTolerance)?
         erasing,
     required TResult orElse(),
-  }) =>
-      throw _privateConstructorUsedError;
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>({
-    required TResult Function(Drawing value) drawing,
-    required TResult Function(Erasing value) erasing,
-  }) =>
-      throw _privateConstructorUsedError;
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>({
-    TResult? Function(Drawing value)? drawing,
-    TResult? Function(Erasing value)? erasing,
-  }) =>
-      throw _privateConstructorUsedError;
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>({
-    TResult Function(Drawing value)? drawing,
-    TResult Function(Erasing value)? erasing,
-    required TResult orElse(),
-  }) =>
-      throw _privateConstructorUsedError;
-
-  /// Serializes this ScribbleState to a JSON map.
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of ScribbleState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  $ScribbleStateCopyWith<ScribbleState> get copyWith =>
-      throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class $ScribbleStateCopyWith<$Res> {
-  factory $ScribbleStateCopyWith(
-          ScribbleState value, $Res Function(ScribbleState) then) =
-      _$ScribbleStateCopyWithImpl<$Res, ScribbleState>;
-  @useResult
-  $Res call(
-      {Sketch sketch,
-      ScribblePointerMode allowedPointersMode,
-      List<int> activePointerIds,
-      Point? pointerPosition,
-      double selectedWidth,
-      double scaleFactor,
-      double simplificationTolerance});
-
-  $SketchCopyWith<$Res> get sketch;
-  $PointCopyWith<$Res>? get pointerPosition;
-}
-
-/// @nodoc
-class _$ScribbleStateCopyWithImpl<$Res, $Val extends ScribbleState>
-    implements $ScribbleStateCopyWith<$Res> {
-  _$ScribbleStateCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  /// Create a copy of ScribbleState
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? sketch = null,
-    Object? allowedPointersMode = null,
-    Object? activePointerIds = null,
-    Object? pointerPosition = freezed,
-    Object? selectedWidth = null,
-    Object? scaleFactor = null,
-    Object? simplificationTolerance = null,
   }) {
-    return _then(_value.copyWith(
-      sketch: null == sketch
-          ? _value.sketch
-          : sketch // ignore: cast_nullable_to_non_nullable
-              as Sketch,
-      allowedPointersMode: null == allowedPointersMode
-          ? _value.allowedPointersMode
-          : allowedPointersMode // ignore: cast_nullable_to_non_nullable
-              as ScribblePointerMode,
-      activePointerIds: null == activePointerIds
-          ? _value.activePointerIds
-          : activePointerIds // ignore: cast_nullable_to_non_nullable
-              as List<int>,
-      pointerPosition: freezed == pointerPosition
-          ? _value.pointerPosition
-          : pointerPosition // ignore: cast_nullable_to_non_nullable
-              as Point?,
-      selectedWidth: null == selectedWidth
-          ? _value.selectedWidth
-          : selectedWidth // ignore: cast_nullable_to_non_nullable
-              as double,
-      scaleFactor: null == scaleFactor
-          ? _value.scaleFactor
-          : scaleFactor // ignore: cast_nullable_to_non_nullable
-              as double,
-      simplificationTolerance: null == simplificationTolerance
-          ? _value.simplificationTolerance
-          : simplificationTolerance // ignore: cast_nullable_to_non_nullable
-              as double,
-    ) as $Val);
-  }
-
-  /// Create a copy of ScribbleState
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $SketchCopyWith<$Res> get sketch {
-    return $SketchCopyWith<$Res>(_value.sketch, (value) {
-      return _then(_value.copyWith(sketch: value) as $Val);
-    });
-  }
-
-  /// Create a copy of ScribbleState
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $PointCopyWith<$Res>? get pointerPosition {
-    if (_value.pointerPosition == null) {
-      return null;
+    final _that = this;
+    switch (_that) {
+      case Drawing() when drawing != null:
+        return drawing(
+            _that.sketch,
+            _that.activeLine,
+            _that.allowedPointersMode,
+            _that.activePointerIds,
+            _that.pointerPosition,
+            _that.selectedColor,
+            _that.selectedWidth,
+            _that.scaleFactor,
+            _that.simplificationTolerance);
+      case Erasing() when erasing != null:
+        return erasing(
+            _that.sketch,
+            _that.allowedPointersMode,
+            _that.activePointerIds,
+            _that.pointerPosition,
+            _that.selectedWidth,
+            _that.scaleFactor,
+            _that.simplificationTolerance);
+      case _:
+        return orElse();
     }
-
-    return $PointCopyWith<$Res>(_value.pointerPosition!, (value) {
-      return _then(_value.copyWith(pointerPosition: value) as $Val);
-    });
   }
-}
 
-/// @nodoc
-abstract class _$$DrawingImplCopyWith<$Res>
-    implements $ScribbleStateCopyWith<$Res> {
-  factory _$$DrawingImplCopyWith(
-          _$DrawingImpl value, $Res Function(_$DrawingImpl) then) =
-      __$$DrawingImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call(
-      {Sketch sketch,
-      SketchLine? activeLine,
-      ScribblePointerMode allowedPointersMode,
-      List<int> activePointerIds,
-      Point? pointerPosition,
-      int selectedColor,
-      double selectedWidth,
-      double scaleFactor,
-      double simplificationTolerance});
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
 
-  @override
-  $SketchCopyWith<$Res> get sketch;
-  $SketchLineCopyWith<$Res>? get activeLine;
-  @override
-  $PointCopyWith<$Res>? get pointerPosition;
-}
-
-/// @nodoc
-class __$$DrawingImplCopyWithImpl<$Res>
-    extends _$ScribbleStateCopyWithImpl<$Res, _$DrawingImpl>
-    implements _$$DrawingImplCopyWith<$Res> {
-  __$$DrawingImplCopyWithImpl(
-      _$DrawingImpl _value, $Res Function(_$DrawingImpl) _then)
-      : super(_value, _then);
-
-  /// Create a copy of ScribbleState
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? sketch = null,
-    Object? activeLine = freezed,
-    Object? allowedPointersMode = null,
-    Object? activePointerIds = null,
-    Object? pointerPosition = freezed,
-    Object? selectedColor = null,
-    Object? selectedWidth = null,
-    Object? scaleFactor = null,
-    Object? simplificationTolerance = null,
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(
+            Sketch sketch,
+            SketchLine? activeLine,
+            ScribblePointerMode allowedPointersMode,
+            List<int> activePointerIds,
+            Point? pointerPosition,
+            int selectedColor,
+            double selectedWidth,
+            double scaleFactor,
+            double simplificationTolerance)
+        drawing,
+    required TResult Function(
+            Sketch sketch,
+            ScribblePointerMode allowedPointersMode,
+            List<int> activePointerIds,
+            Point? pointerPosition,
+            double selectedWidth,
+            double scaleFactor,
+            double simplificationTolerance)
+        erasing,
   }) {
-    return _then(_$DrawingImpl(
-      sketch: null == sketch
-          ? _value.sketch
-          : sketch // ignore: cast_nullable_to_non_nullable
-              as Sketch,
-      activeLine: freezed == activeLine
-          ? _value.activeLine
-          : activeLine // ignore: cast_nullable_to_non_nullable
-              as SketchLine?,
-      allowedPointersMode: null == allowedPointersMode
-          ? _value.allowedPointersMode
-          : allowedPointersMode // ignore: cast_nullable_to_non_nullable
-              as ScribblePointerMode,
-      activePointerIds: null == activePointerIds
-          ? _value._activePointerIds
-          : activePointerIds // ignore: cast_nullable_to_non_nullable
-              as List<int>,
-      pointerPosition: freezed == pointerPosition
-          ? _value.pointerPosition
-          : pointerPosition // ignore: cast_nullable_to_non_nullable
-              as Point?,
-      selectedColor: null == selectedColor
-          ? _value.selectedColor
-          : selectedColor // ignore: cast_nullable_to_non_nullable
-              as int,
-      selectedWidth: null == selectedWidth
-          ? _value.selectedWidth
-          : selectedWidth // ignore: cast_nullable_to_non_nullable
-              as double,
-      scaleFactor: null == scaleFactor
-          ? _value.scaleFactor
-          : scaleFactor // ignore: cast_nullable_to_non_nullable
-              as double,
-      simplificationTolerance: null == simplificationTolerance
-          ? _value.simplificationTolerance
-          : simplificationTolerance // ignore: cast_nullable_to_non_nullable
-              as double,
-    ));
+    final _that = this;
+    switch (_that) {
+      case Drawing():
+        return drawing(
+            _that.sketch,
+            _that.activeLine,
+            _that.allowedPointersMode,
+            _that.activePointerIds,
+            _that.pointerPosition,
+            _that.selectedColor,
+            _that.selectedWidth,
+            _that.scaleFactor,
+            _that.simplificationTolerance);
+      case Erasing():
+        return erasing(
+            _that.sketch,
+            _that.allowedPointersMode,
+            _that.activePointerIds,
+            _that.pointerPosition,
+            _that.selectedWidth,
+            _that.scaleFactor,
+            _that.simplificationTolerance);
+    }
   }
 
-  /// Create a copy of ScribbleState
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $SketchLineCopyWith<$Res>? get activeLine {
-    if (_value.activeLine == null) {
-      return null;
-    }
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
 
-    return $SketchLineCopyWith<$Res>(_value.activeLine!, (value) {
-      return _then(_value.copyWith(activeLine: value));
-    });
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(
+            Sketch sketch,
+            SketchLine? activeLine,
+            ScribblePointerMode allowedPointersMode,
+            List<int> activePointerIds,
+            Point? pointerPosition,
+            int selectedColor,
+            double selectedWidth,
+            double scaleFactor,
+            double simplificationTolerance)?
+        drawing,
+    TResult? Function(
+            Sketch sketch,
+            ScribblePointerMode allowedPointersMode,
+            List<int> activePointerIds,
+            Point? pointerPosition,
+            double selectedWidth,
+            double scaleFactor,
+            double simplificationTolerance)?
+        erasing,
+  }) {
+    final _that = this;
+    switch (_that) {
+      case Drawing() when drawing != null:
+        return drawing(
+            _that.sketch,
+            _that.activeLine,
+            _that.allowedPointersMode,
+            _that.activePointerIds,
+            _that.pointerPosition,
+            _that.selectedColor,
+            _that.selectedWidth,
+            _that.scaleFactor,
+            _that.simplificationTolerance);
+      case Erasing() when erasing != null:
+        return erasing(
+            _that.sketch,
+            _that.allowedPointersMode,
+            _that.activePointerIds,
+            _that.pointerPosition,
+            _that.selectedWidth,
+            _that.scaleFactor,
+            _that.simplificationTolerance);
+      case _:
+        return null;
+    }
   }
 }
 
 /// @nodoc
 @JsonSerializable()
-class _$DrawingImpl extends Drawing {
-  const _$DrawingImpl(
+class Drawing extends ScribbleState {
+  const Drawing(
       {required this.sketch,
       this.activeLine,
       this.allowedPointersMode = ScribblePointerMode.all,
@@ -385,16 +496,14 @@ class _$DrawingImpl extends Drawing {
       : _activePointerIds = activePointerIds,
         $type = $type ?? 'drawing',
         super._();
-
-  factory _$DrawingImpl.fromJson(Map<String, dynamic> json) =>
-      _$$DrawingImplFromJson(json);
+  factory Drawing.fromJson(Map<String, dynamic> json) =>
+      _$DrawingFromJson(json);
 
   /// The current state of the sketch
   @override
   final Sketch sketch;
 
   /// The line that is currently being drawn
-  @override
   final SketchLine? activeLine;
 
   /// Which pointers are allowed for drawing and will be captured by the
@@ -423,7 +532,6 @@ class _$DrawingImpl extends Drawing {
   final Point? pointerPosition;
 
   /// The color that is currently being drawn with
-  @override
   @JsonKey()
   final int selectedColor;
 
@@ -455,16 +563,26 @@ class _$DrawingImpl extends Drawing {
   @JsonKey(name: 'runtimeType')
   final String $type;
 
+  /// Create a copy of ScribbleState
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  String toString() {
-    return 'ScribbleState.drawing(sketch: $sketch, activeLine: $activeLine, allowedPointersMode: $allowedPointersMode, activePointerIds: $activePointerIds, pointerPosition: $pointerPosition, selectedColor: $selectedColor, selectedWidth: $selectedWidth, scaleFactor: $scaleFactor, simplificationTolerance: $simplificationTolerance)';
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $DrawingCopyWith<Drawing> get copyWith =>
+      _$DrawingCopyWithImpl<Drawing>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$DrawingToJson(
+      this,
+    );
   }
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$DrawingImpl &&
+            other is Drawing &&
             (identical(other.sketch, sketch) || other.sketch == sketch) &&
             (identical(other.activeLine, activeLine) ||
                 other.activeLine == activeLine) &&
@@ -499,315 +617,142 @@ class _$DrawingImpl extends Drawing {
       scaleFactor,
       simplificationTolerance);
 
-  /// Create a copy of ScribbleState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  @pragma('vm:prefer-inline')
-  _$$DrawingImplCopyWith<_$DrawingImpl> get copyWith =>
-      __$$DrawingImplCopyWithImpl<_$DrawingImpl>(this, _$identity);
-
-  @override
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>({
-    required TResult Function(
-            Sketch sketch,
-            SketchLine? activeLine,
-            ScribblePointerMode allowedPointersMode,
-            List<int> activePointerIds,
-            Point? pointerPosition,
-            int selectedColor,
-            double selectedWidth,
-            double scaleFactor,
-            double simplificationTolerance)
-        drawing,
-    required TResult Function(
-            Sketch sketch,
-            ScribblePointerMode allowedPointersMode,
-            List<int> activePointerIds,
-            Point? pointerPosition,
-            double selectedWidth,
-            double scaleFactor,
-            double simplificationTolerance)
-        erasing,
-  }) {
-    return drawing(
-        sketch,
-        activeLine,
-        allowedPointersMode,
-        activePointerIds,
-        pointerPosition,
-        selectedColor,
-        selectedWidth,
-        scaleFactor,
-        simplificationTolerance);
+  String toString() {
+    return 'ScribbleState.drawing(sketch: $sketch, activeLine: $activeLine, allowedPointersMode: $allowedPointersMode, activePointerIds: $activePointerIds, pointerPosition: $pointerPosition, selectedColor: $selectedColor, selectedWidth: $selectedWidth, scaleFactor: $scaleFactor, simplificationTolerance: $simplificationTolerance)';
   }
-
-  @override
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function(
-            Sketch sketch,
-            SketchLine? activeLine,
-            ScribblePointerMode allowedPointersMode,
-            List<int> activePointerIds,
-            Point? pointerPosition,
-            int selectedColor,
-            double selectedWidth,
-            double scaleFactor,
-            double simplificationTolerance)?
-        drawing,
-    TResult? Function(
-            Sketch sketch,
-            ScribblePointerMode allowedPointersMode,
-            List<int> activePointerIds,
-            Point? pointerPosition,
-            double selectedWidth,
-            double scaleFactor,
-            double simplificationTolerance)?
-        erasing,
-  }) {
-    return drawing?.call(
-        sketch,
-        activeLine,
-        allowedPointersMode,
-        activePointerIds,
-        pointerPosition,
-        selectedColor,
-        selectedWidth,
-        scaleFactor,
-        simplificationTolerance);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>({
-    TResult Function(
-            Sketch sketch,
-            SketchLine? activeLine,
-            ScribblePointerMode allowedPointersMode,
-            List<int> activePointerIds,
-            Point? pointerPosition,
-            int selectedColor,
-            double selectedWidth,
-            double scaleFactor,
-            double simplificationTolerance)?
-        drawing,
-    TResult Function(
-            Sketch sketch,
-            ScribblePointerMode allowedPointersMode,
-            List<int> activePointerIds,
-            Point? pointerPosition,
-            double selectedWidth,
-            double scaleFactor,
-            double simplificationTolerance)?
-        erasing,
-    required TResult orElse(),
-  }) {
-    if (drawing != null) {
-      return drawing(
-          sketch,
-          activeLine,
-          allowedPointersMode,
-          activePointerIds,
-          pointerPosition,
-          selectedColor,
-          selectedWidth,
-          scaleFactor,
-          simplificationTolerance);
-    }
-    return orElse();
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>({
-    required TResult Function(Drawing value) drawing,
-    required TResult Function(Erasing value) erasing,
-  }) {
-    return drawing(this);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>({
-    TResult? Function(Drawing value)? drawing,
-    TResult? Function(Erasing value)? erasing,
-  }) {
-    return drawing?.call(this);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>({
-    TResult Function(Drawing value)? drawing,
-    TResult Function(Erasing value)? erasing,
-    required TResult orElse(),
-  }) {
-    if (drawing != null) {
-      return drawing(this);
-    }
-    return orElse();
-  }
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$DrawingImplToJson(
-      this,
-    );
-  }
-}
-
-abstract class Drawing extends ScribbleState {
-  const factory Drawing(
-      {required final Sketch sketch,
-      final SketchLine? activeLine,
-      final ScribblePointerMode allowedPointersMode,
-      final List<int> activePointerIds,
-      final Point? pointerPosition,
-      final int selectedColor,
-      final double selectedWidth,
-      final double scaleFactor,
-      final double simplificationTolerance}) = _$DrawingImpl;
-  const Drawing._() : super._();
-
-  factory Drawing.fromJson(Map<String, dynamic> json) = _$DrawingImpl.fromJson;
-
-  /// The current state of the sketch
-  @override
-  Sketch get sketch;
-
-  /// The line that is currently being drawn
-  SketchLine? get activeLine;
-
-  /// Which pointers are allowed for drawing and will be captured by the
-  /// scribble widget.
-  @override
-  ScribblePointerMode get allowedPointersMode;
-
-  /// The ids of all supported pointers that are currently interacting with
-  /// the widget.
-  @override
-  List<int> get activePointerIds;
-
-  /// The current position of the pointer
-  @override
-  Point? get pointerPosition;
-
-  /// The color that is currently being drawn with
-  int get selectedColor;
-
-  /// The current width of the pen
-  @override
-  double get selectedWidth;
-
-  /// {@template view.state.scribble_state.scale_factor}
-  /// How much the widget is scaled at the moment.
-  ///
-  /// Can be used if zoom functionality is needed
-  /// (e.g. through InteractiveViewer) so that the pen width remains the same.
-  /// {@endtemplate}
-  @override
-  double get scaleFactor;
-
-  /// {@template view.state.scribble_state.simplification_tolerance}
-  /// The current tolerance of simplification, in pixels.
-  ///
-  /// Lines will be simplified when they are finished. A value of 0 (default)
-  /// will mean no simplification.
-  /// {@endtemplate}
-  @override
-  double get simplificationTolerance;
-
-  /// Create a copy of ScribbleState
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$DrawingImplCopyWith<_$DrawingImpl> get copyWith =>
-      throw _privateConstructorUsedError;
 }
 
 /// @nodoc
-abstract class _$$ErasingImplCopyWith<$Res>
+abstract mixin class $DrawingCopyWith<$Res>
     implements $ScribbleStateCopyWith<$Res> {
-  factory _$$ErasingImplCopyWith(
-          _$ErasingImpl value, $Res Function(_$ErasingImpl) then) =
-      __$$ErasingImplCopyWithImpl<$Res>;
+  factory $DrawingCopyWith(Drawing value, $Res Function(Drawing) _then) =
+      _$DrawingCopyWithImpl;
   @override
   @useResult
   $Res call(
       {Sketch sketch,
+      SketchLine? activeLine,
       ScribblePointerMode allowedPointersMode,
       List<int> activePointerIds,
       Point? pointerPosition,
+      int selectedColor,
       double selectedWidth,
       double scaleFactor,
       double simplificationTolerance});
 
   @override
   $SketchCopyWith<$Res> get sketch;
+  $SketchLineCopyWith<$Res>? get activeLine;
   @override
   $PointCopyWith<$Res>? get pointerPosition;
 }
 
 /// @nodoc
-class __$$ErasingImplCopyWithImpl<$Res>
-    extends _$ScribbleStateCopyWithImpl<$Res, _$ErasingImpl>
-    implements _$$ErasingImplCopyWith<$Res> {
-  __$$ErasingImplCopyWithImpl(
-      _$ErasingImpl _value, $Res Function(_$ErasingImpl) _then)
-      : super(_value, _then);
+class _$DrawingCopyWithImpl<$Res> implements $DrawingCopyWith<$Res> {
+  _$DrawingCopyWithImpl(this._self, this._then);
+
+  final Drawing _self;
+  final $Res Function(Drawing) _then;
 
   /// Create a copy of ScribbleState
   /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
   @override
+  @pragma('vm:prefer-inline')
   $Res call({
     Object? sketch = null,
+    Object? activeLine = freezed,
     Object? allowedPointersMode = null,
     Object? activePointerIds = null,
     Object? pointerPosition = freezed,
+    Object? selectedColor = null,
     Object? selectedWidth = null,
     Object? scaleFactor = null,
     Object? simplificationTolerance = null,
   }) {
-    return _then(_$ErasingImpl(
+    return _then(Drawing(
       sketch: null == sketch
-          ? _value.sketch
+          ? _self.sketch
           : sketch // ignore: cast_nullable_to_non_nullable
               as Sketch,
+      activeLine: freezed == activeLine
+          ? _self.activeLine
+          : activeLine // ignore: cast_nullable_to_non_nullable
+              as SketchLine?,
       allowedPointersMode: null == allowedPointersMode
-          ? _value.allowedPointersMode
+          ? _self.allowedPointersMode
           : allowedPointersMode // ignore: cast_nullable_to_non_nullable
               as ScribblePointerMode,
       activePointerIds: null == activePointerIds
-          ? _value._activePointerIds
+          ? _self._activePointerIds
           : activePointerIds // ignore: cast_nullable_to_non_nullable
               as List<int>,
       pointerPosition: freezed == pointerPosition
-          ? _value.pointerPosition
+          ? _self.pointerPosition
           : pointerPosition // ignore: cast_nullable_to_non_nullable
               as Point?,
+      selectedColor: null == selectedColor
+          ? _self.selectedColor
+          : selectedColor // ignore: cast_nullable_to_non_nullable
+              as int,
       selectedWidth: null == selectedWidth
-          ? _value.selectedWidth
+          ? _self.selectedWidth
           : selectedWidth // ignore: cast_nullable_to_non_nullable
               as double,
       scaleFactor: null == scaleFactor
-          ? _value.scaleFactor
+          ? _self.scaleFactor
           : scaleFactor // ignore: cast_nullable_to_non_nullable
               as double,
       simplificationTolerance: null == simplificationTolerance
-          ? _value.simplificationTolerance
+          ? _self.simplificationTolerance
           : simplificationTolerance // ignore: cast_nullable_to_non_nullable
               as double,
     ));
+  }
+
+  /// Create a copy of ScribbleState
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $SketchCopyWith<$Res> get sketch {
+    return $SketchCopyWith<$Res>(_self.sketch, (value) {
+      return _then(_self.copyWith(sketch: value));
+    });
+  }
+
+  /// Create a copy of ScribbleState
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $SketchLineCopyWith<$Res>? get activeLine {
+    if (_self.activeLine == null) {
+      return null;
+    }
+
+    return $SketchLineCopyWith<$Res>(_self.activeLine!, (value) {
+      return _then(_self.copyWith(activeLine: value));
+    });
+  }
+
+  /// Create a copy of ScribbleState
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $PointCopyWith<$Res>? get pointerPosition {
+    if (_self.pointerPosition == null) {
+      return null;
+    }
+
+    return $PointCopyWith<$Res>(_self.pointerPosition!, (value) {
+      return _then(_self.copyWith(pointerPosition: value));
+    });
   }
 }
 
 /// @nodoc
 @JsonSerializable()
-class _$ErasingImpl extends Erasing {
-  const _$ErasingImpl(
+class Erasing extends ScribbleState {
+  const Erasing(
       {required this.sketch,
       this.allowedPointersMode = ScribblePointerMode.all,
       final List<int> activePointerIds = const [],
@@ -819,9 +764,8 @@ class _$ErasingImpl extends Erasing {
       : _activePointerIds = activePointerIds,
         $type = $type ?? 'erasing',
         super._();
-
-  factory _$ErasingImpl.fromJson(Map<String, dynamic> json) =>
-      _$$ErasingImplFromJson(json);
+  factory Erasing.fromJson(Map<String, dynamic> json) =>
+      _$ErasingFromJson(json);
 
   /// The current state of the sketch
   @override
@@ -876,16 +820,26 @@ class _$ErasingImpl extends Erasing {
   @JsonKey(name: 'runtimeType')
   final String $type;
 
+  /// Create a copy of ScribbleState
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  String toString() {
-    return 'ScribbleState.erasing(sketch: $sketch, allowedPointersMode: $allowedPointersMode, activePointerIds: $activePointerIds, pointerPosition: $pointerPosition, selectedWidth: $selectedWidth, scaleFactor: $scaleFactor, simplificationTolerance: $simplificationTolerance)';
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $ErasingCopyWith<Erasing> get copyWith =>
+      _$ErasingCopyWithImpl<Erasing>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$ErasingToJson(
+      this,
+    );
   }
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$ErasingImpl &&
+            other is Erasing &&
             (identical(other.sketch, sketch) || other.sketch == sketch) &&
             (identical(other.allowedPointersMode, allowedPointersMode) ||
                 other.allowedPointersMode == allowedPointersMode) &&
@@ -914,194 +868,109 @@ class _$ErasingImpl extends Erasing {
       scaleFactor,
       simplificationTolerance);
 
+  @override
+  String toString() {
+    return 'ScribbleState.erasing(sketch: $sketch, allowedPointersMode: $allowedPointersMode, activePointerIds: $activePointerIds, pointerPosition: $pointerPosition, selectedWidth: $selectedWidth, scaleFactor: $scaleFactor, simplificationTolerance: $simplificationTolerance)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $ErasingCopyWith<$Res>
+    implements $ScribbleStateCopyWith<$Res> {
+  factory $ErasingCopyWith(Erasing value, $Res Function(Erasing) _then) =
+      _$ErasingCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {Sketch sketch,
+      ScribblePointerMode allowedPointersMode,
+      List<int> activePointerIds,
+      Point? pointerPosition,
+      double selectedWidth,
+      double scaleFactor,
+      double simplificationTolerance});
+
+  @override
+  $SketchCopyWith<$Res> get sketch;
+  @override
+  $PointCopyWith<$Res>? get pointerPosition;
+}
+
+/// @nodoc
+class _$ErasingCopyWithImpl<$Res> implements $ErasingCopyWith<$Res> {
+  _$ErasingCopyWithImpl(this._self, this._then);
+
+  final Erasing _self;
+  final $Res Function(Erasing) _then;
+
   /// Create a copy of ScribbleState
   /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
-  _$$ErasingImplCopyWith<_$ErasingImpl> get copyWith =>
-      __$$ErasingImplCopyWithImpl<_$ErasingImpl>(this, _$identity);
-
-  @override
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>({
-    required TResult Function(
-            Sketch sketch,
-            SketchLine? activeLine,
-            ScribblePointerMode allowedPointersMode,
-            List<int> activePointerIds,
-            Point? pointerPosition,
-            int selectedColor,
-            double selectedWidth,
-            double scaleFactor,
-            double simplificationTolerance)
-        drawing,
-    required TResult Function(
-            Sketch sketch,
-            ScribblePointerMode allowedPointersMode,
-            List<int> activePointerIds,
-            Point? pointerPosition,
-            double selectedWidth,
-            double scaleFactor,
-            double simplificationTolerance)
-        erasing,
+  $Res call({
+    Object? sketch = null,
+    Object? allowedPointersMode = null,
+    Object? activePointerIds = null,
+    Object? pointerPosition = freezed,
+    Object? selectedWidth = null,
+    Object? scaleFactor = null,
+    Object? simplificationTolerance = null,
   }) {
-    return erasing(sketch, allowedPointersMode, activePointerIds,
-        pointerPosition, selectedWidth, scaleFactor, simplificationTolerance);
+    return _then(Erasing(
+      sketch: null == sketch
+          ? _self.sketch
+          : sketch // ignore: cast_nullable_to_non_nullable
+              as Sketch,
+      allowedPointersMode: null == allowedPointersMode
+          ? _self.allowedPointersMode
+          : allowedPointersMode // ignore: cast_nullable_to_non_nullable
+              as ScribblePointerMode,
+      activePointerIds: null == activePointerIds
+          ? _self._activePointerIds
+          : activePointerIds // ignore: cast_nullable_to_non_nullable
+              as List<int>,
+      pointerPosition: freezed == pointerPosition
+          ? _self.pointerPosition
+          : pointerPosition // ignore: cast_nullable_to_non_nullable
+              as Point?,
+      selectedWidth: null == selectedWidth
+          ? _self.selectedWidth
+          : selectedWidth // ignore: cast_nullable_to_non_nullable
+              as double,
+      scaleFactor: null == scaleFactor
+          ? _self.scaleFactor
+          : scaleFactor // ignore: cast_nullable_to_non_nullable
+              as double,
+      simplificationTolerance: null == simplificationTolerance
+          ? _self.simplificationTolerance
+          : simplificationTolerance // ignore: cast_nullable_to_non_nullable
+              as double,
+    ));
   }
-
-  @override
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function(
-            Sketch sketch,
-            SketchLine? activeLine,
-            ScribblePointerMode allowedPointersMode,
-            List<int> activePointerIds,
-            Point? pointerPosition,
-            int selectedColor,
-            double selectedWidth,
-            double scaleFactor,
-            double simplificationTolerance)?
-        drawing,
-    TResult? Function(
-            Sketch sketch,
-            ScribblePointerMode allowedPointersMode,
-            List<int> activePointerIds,
-            Point? pointerPosition,
-            double selectedWidth,
-            double scaleFactor,
-            double simplificationTolerance)?
-        erasing,
-  }) {
-    return erasing?.call(sketch, allowedPointersMode, activePointerIds,
-        pointerPosition, selectedWidth, scaleFactor, simplificationTolerance);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>({
-    TResult Function(
-            Sketch sketch,
-            SketchLine? activeLine,
-            ScribblePointerMode allowedPointersMode,
-            List<int> activePointerIds,
-            Point? pointerPosition,
-            int selectedColor,
-            double selectedWidth,
-            double scaleFactor,
-            double simplificationTolerance)?
-        drawing,
-    TResult Function(
-            Sketch sketch,
-            ScribblePointerMode allowedPointersMode,
-            List<int> activePointerIds,
-            Point? pointerPosition,
-            double selectedWidth,
-            double scaleFactor,
-            double simplificationTolerance)?
-        erasing,
-    required TResult orElse(),
-  }) {
-    if (erasing != null) {
-      return erasing(sketch, allowedPointersMode, activePointerIds,
-          pointerPosition, selectedWidth, scaleFactor, simplificationTolerance);
-    }
-    return orElse();
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>({
-    required TResult Function(Drawing value) drawing,
-    required TResult Function(Erasing value) erasing,
-  }) {
-    return erasing(this);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>({
-    TResult? Function(Drawing value)? drawing,
-    TResult? Function(Erasing value)? erasing,
-  }) {
-    return erasing?.call(this);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>({
-    TResult Function(Drawing value)? drawing,
-    TResult Function(Erasing value)? erasing,
-    required TResult orElse(),
-  }) {
-    if (erasing != null) {
-      return erasing(this);
-    }
-    return orElse();
-  }
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$ErasingImplToJson(
-      this,
-    );
-  }
-}
-
-abstract class Erasing extends ScribbleState {
-  const factory Erasing(
-      {required final Sketch sketch,
-      final ScribblePointerMode allowedPointersMode,
-      final List<int> activePointerIds,
-      final Point? pointerPosition,
-      final double selectedWidth,
-      final double scaleFactor,
-      final double simplificationTolerance}) = _$ErasingImpl;
-  const Erasing._() : super._();
-
-  factory Erasing.fromJson(Map<String, dynamic> json) = _$ErasingImpl.fromJson;
-
-  /// The current state of the sketch
-  @override
-  Sketch get sketch;
-
-  /// Which pointers are allowed for drawing and will be captured by the
-  /// scribble widget.
-  @override
-  ScribblePointerMode get allowedPointersMode;
-
-  /// The ids of all supported pointers that are currently interacting with
-  /// the widget.
-  @override
-  List<int> get activePointerIds;
-
-  /// The current position of the pointer
-  @override
-  Point? get pointerPosition;
-
-  /// The current width of the pen
-  @override
-  double get selectedWidth;
-
-  /// How much the widget is scaled at the moment.
-  ///
-  /// Can be used if zoom functionality is needed
-  /// (e.g. through InteractiveViewer) so that the pen width remains the same.
-  @override
-  double get scaleFactor;
-
-  /// The current tolerance of simplification, in pixels.
-  ///
-  /// Lines will be simplified when they are finished. A value of 0 (default)
-  /// will mean no simplification.
-  @override
-  double get simplificationTolerance;
 
   /// Create a copy of ScribbleState
   /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$ErasingImplCopyWith<_$ErasingImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+  @pragma('vm:prefer-inline')
+  $SketchCopyWith<$Res> get sketch {
+    return $SketchCopyWith<$Res>(_self.sketch, (value) {
+      return _then(_self.copyWith(sketch: value));
+    });
+  }
+
+  /// Create a copy of ScribbleState
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $PointCopyWith<$Res>? get pointerPosition {
+    if (_self.pointerPosition == null) {
+      return null;
+    }
+
+    return $PointCopyWith<$Res>(_self.pointerPosition!, (value) {
+      return _then(_self.copyWith(pointerPosition: value));
+    });
+  }
 }
+
+// dart format on

--- a/lib/src/view/state/scribble.state.g.dart
+++ b/lib/src/view/state/scribble.state.g.dart
@@ -6,8 +6,7 @@ part of 'scribble.state.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$DrawingImpl _$$DrawingImplFromJson(Map<String, dynamic> json) =>
-    _$DrawingImpl(
+Drawing _$DrawingFromJson(Map<String, dynamic> json) => Drawing(
       sketch: Sketch.fromJson(json['sketch'] as Map<String, dynamic>),
       activeLine: json['activeLine'] == null
           ? null
@@ -30,8 +29,7 @@ _$DrawingImpl _$$DrawingImplFromJson(Map<String, dynamic> json) =>
       $type: json['runtimeType'] as String?,
     );
 
-Map<String, dynamic> _$$DrawingImplToJson(_$DrawingImpl instance) =>
-    <String, dynamic>{
+Map<String, dynamic> _$DrawingToJson(Drawing instance) => <String, dynamic>{
       'sketch': instance.sketch.toJson(),
       'activeLine': instance.activeLine?.toJson(),
       'allowedPointersMode':
@@ -52,8 +50,7 @@ const _$ScribblePointerModeEnumMap = {
   ScribblePointerMode.mouseAndPen: 'mouseAndPen',
 };
 
-_$ErasingImpl _$$ErasingImplFromJson(Map<String, dynamic> json) =>
-    _$ErasingImpl(
+Erasing _$ErasingFromJson(Map<String, dynamic> json) => Erasing(
       sketch: Sketch.fromJson(json['sketch'] as Map<String, dynamic>),
       allowedPointersMode: $enumDecodeNullable(
               _$ScribblePointerModeEnumMap, json['allowedPointersMode']) ??
@@ -72,8 +69,7 @@ _$ErasingImpl _$$ErasingImplFromJson(Map<String, dynamic> json) =>
       $type: json['runtimeType'] as String?,
     );
 
-Map<String, dynamic> _$$ErasingImplToJson(_$ErasingImpl instance) =>
-    <String, dynamic>{
+Map<String, dynamic> _$ErasingToJson(Erasing instance) => <String, dynamic>{
       'sketch': instance.sketch.toJson(),
       'allowedPointersMode':
           _$ScribblePointerModeEnumMap[instance.allowedPointersMode]!,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  freezed_annotation: ^3.1.0
+  freezed_annotation: ">=2.4.1 <4.0.0"
   perfect_freehand: ^2.3.2
   simpli: ^0.1.1
   value_notifier_tools: ^0.1.2
@@ -21,7 +21,7 @@ dev_dependencies:
   build_runner: ^2.4.9
   flutter_test:
     sdk: flutter
-  freezed: ^3.2.5
+  freezed: ">=2.4.7 <4.0.0"
   json_serializable: ^6.9.5
   lintervention: ^0.3.1
   melos: ^6.3.3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  freezed_annotation: ">=2.4.1 <3.0.0"
+  freezed_annotation: ^3.1.0
   perfect_freehand: ^2.3.2
   simpli: ^0.1.1
   value_notifier_tools: ^0.1.2
@@ -21,7 +21,7 @@ dev_dependencies:
   build_runner: ^2.4.9
   flutter_test:
     sdk: flutter
-  freezed: ^2.4.7
+  freezed: ^3.2.5
   json_serializable: ^6.9.5
   lintervention: ^0.3.1
   melos: ^6.3.3


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

This updates the version constraints of `freezed` and `freezed_annotation` to support freezed 3.x versions.

Instead of using `freezed: ^3.0.0`, I opted into using `freezed: ">=2.4.7 <4.0.0"` to allow using both freezed 3 and freezed 2, as updating to freezed 3 can be quite substantial.

Although it is compatible with freezed 2, the models were generated with freezed 3, so this is a breaking change, as `.map/.when` are [no longer generated](https://github.com/rrousselGit/freezed/blob/master/packages/freezed/migration_guide.md#pattern-matching), and `Sketch` is exposed. However updating the codebase to use pattern matching is probably less of a hassle than generally adopting freezed 3 and potentially riverpod 3.

This should also close: https://github.com/timcreatedit/scribble/pull/78

## Checklist

<!--- Put an `x` in all the boxes that apply: -->
- [x] My PR title is in the style of [conventional commits](https://www.conventionalcommits.org/)
- [x] All public facing APIs are documented with [dartdoc](https://dart.dev/guides/language/effective-dart/documentation)
- [x] I have added tests to cover my changes
